### PR TITLE
adding HEALTHCHECK instruction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,23 +5,28 @@ FROM debian:stretch-slim
 ENV ACESTREAM_VERSION 3.1.49
 
 # prepare dependencies for acestream
-RUN apt-get -q update                                       \
- && apt-get install -y --no-install-recommends libpython2.7 \
-        net-tools                                           \
-        python-minimal                                      \
-        python-pkg-resources                                \
-        python-m2crypto                                     \
-        python-apsw                                         \
-        python-lxml                                         \
-        wget                                                \
- && apt-get clean                                           \
- && rm -rf /var/lib/apt/lists/*                             \
+RUN apt-get -q update                          \
+ && apt-get install -y --no-install-recommends \
+        libpython2.7                           \
+        netcat                                 \
+        net-tools                              \
+        python-minimal                         \
+        python-pkg-resources                   \
+        python-m2crypto                        \
+        python-apsw                            \
+        python-lxml                            \
+        wget                                   \
+ && apt-get clean                              \
+ && rm -rf /var/lib/apt/lists/*                \
            /var/cache/*
 
 # download and extract acestream
 RUN mkdir --parents /opt/acestream \
  && wget -qO- "http://acestream.org/downloads/linux/acestream_${ACESTREAM_VERSION}_debian_9.9_x86_64.tar.gz" |\
     tar --extract --gzip --directory /opt/acestream
+
+# let docker know how to test container health
+HEALTHCHECK CMD nc -zv localhost 6878 || exit 1
 
 # start acestream (client console only)
 ENTRYPOINT [ "/opt/acestream/start-engine", "--client-console" ]

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CONTAINER_NAME=acestream
 IMAGE=cturra/$(CONTAINER_NAME)
 # ---------
 
-.PHONY: build logs run shell start stats stop
+.PHONY: build logs run shell start stats status stop
 
 
 build:
@@ -31,6 +31,10 @@ start:	run
 
 stats:
 	docker stats $(CONTAINER_NAME)
+
+
+status:
+	docker ps --filter "name=$(CONTAINER_NAME)"
 
 
 stop:

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ run:
 
 
 shell:
-	docker exec -ti $(CONTAINER_NAME) /bin/sh
+	docker exec -ti $(CONTAINER_NAME) /bin/bash
 
 
 start:	run

--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ $> make stats
 ```
 
 
+### Status
+:warning: Requirement: container is [running](#run-or-start)
+
+Display the details about the running container.
+
+```
+$> make status
+```
+
 ## Connecting to Stream
 Once the container is running, connect to the network stream with a multimedia player like [VLC](http://www.videolan.org/) from the same or another
 computer on your network.


### PR DESCRIPTION
this instructs docker how to validate the health of the container.

=> https://docs.docker.com/engine/reference/builder/#healthcheck

example from my local environment:
```
$> make status
docker ps --filter "name=acestream"
CONTAINER ID        IMAGE                     COMMAND                  CREATED             STATUS                   PORTS                    NAMES
5b982252077d        cturra/acestream:latest   "/opt/acestream/star…"   8 minutes ago       Up 8 minutes (healthy)   0.0.0.0:6878->6878/tcp   acestream
```